### PR TITLE
Allow to specify helm location

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ From the root of this repo, run the following:
 make acceptance
 ```
 
+Note: by default, the tests will use helm as found on your PATH.
+To specify a different helm to test, set and export the `ROBOT_HELM_PATH`
+environment variable.  For example, if you have helm v2 installed, but want
+to test helm v3 which is located elsewhere; or if you have helm installed
+but want to test a different development version of helm.
+
 ## Viewing the results
 
 Robot creates an HTML test report describing test successes/failures.

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -32,6 +32,9 @@ ROBOT_TEST_ROOT_DIR="${ROBOT_TEST_ROOT_DIR:-${PWD}}"
 #   - fresh Helm Home at .acceptance/.helm/
 #   - Python virtualenv at .acceptance/.venv/ (cached if already fetched)
 #
+if [ ! -z "${ROBOT_HELM_PATH}" ]; then
+   export PATH="${ROBOT_HELM_PATH}:${PATH}"
+fi
 export PATH="${VENV_DIR}/bin:${PATH}"
 export HELM_HOME="${ROBOT_OUTPUT_DIR}/.helm"
 rm -rf ${HELM_HOME} && mkdir -p ${HELM_HOME}

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -38,6 +38,28 @@ fi
 export PATH="${VENV_DIR}/bin:${PATH}"
 export HELM_HOME="${ROBOT_OUTPUT_DIR}/.helm"
 rm -rf ${HELM_HOME} && mkdir -p ${HELM_HOME}
+
+# We only support helm v3 at this time.
+# To figure out which version of helm is used, we run 'helm version'
+# with the -c flag which is only supported in helm v2; if we get an
+# error, it means we are running helm v3, if we don't get an error,
+# it's helm v2 and we abort. We want to use the -c flag because if
+# we end up on helm v2 and we don't have that flag, it will try to
+# contact the cluster, which may not be accessible, and the command
+# will timeout.
+#
+# It is important not to run with helm v2 or else the 'helm init'
+# command will try to setup tiller on whatever cluster the user
+# is currently pointing to since we haven't setup the kind cluster yet.
+set +x
+if helm version -c > /dev/null; then
+    echo "Helm v2 not supported yet!"
+    echo "Please set the ROBOT_HELM_PATH environment variable" \
+         "to the directory where the helm v3 to test can be found."
+    exit 1
+fi
+set -x
+
 helm init
 if [[ ! -d ${ROBOT_VENV_DIR} ]]; then
     virtualenv -p $(which python3) ${ROBOT_VENV_DIR}


### PR DESCRIPTION
For people such as myself that use helm outside of development, the helm that is on their PATH is usually not the one they want to run the acceptance tests on.

This PR allows to specify which helm to test using ROBOT_HELM_PATH.

This PR also blocks helm v2 from being used as it could mistakenly affect the user's real cluster.

I would have preferred a separate PR, but since blocking helm v2 tells the user to use ROBOT_HELM_PATH, the two changes became dependant.