### PR TITLE
 Wrong variable prevents from finding correct tools 

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -35,7 +35,7 @@ ROBOT_TEST_ROOT_DIR="${ROBOT_TEST_ROOT_DIR:-${PWD}}"
 if [ ! -z "${ROBOT_HELM_PATH}" ]; then
    export PATH="${ROBOT_HELM_PATH}:${PATH}"
 fi
-export PATH="${VENV_DIR}/bin:${PATH}"
+export PATH="${ROBOT_VENV_DIR}/bin:${PATH}"
 export HELM_HOME="${ROBOT_HELM_HOME_DIR}"
 rm -rf ${HELM_HOME} && mkdir -p ${HELM_HOME}
 

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -52,7 +52,7 @@ rm -rf ${HELM_HOME} && mkdir -p ${HELM_HOME}
 # command will try to setup tiller on whatever cluster the user
 # is currently pointing to since we haven't setup the kind cluster yet.
 set +x
-if helm version -c > /dev/null; then
+if helm version -c &> /dev/null; then
     echo "Helm v2 not supported yet!"
     echo "Please set the ROBOT_HELM_PATH environment variable" \
          "to the directory where the helm v3 to test can be found."


### PR DESCRIPTION
My pip installation is for python2 so things didn't work until the PATH was properly set to point to the virtualenv bin directory which has pip installed for python3.

Also, I had forgotten to send stderr to /dev/null when checking for helm v3, so there was an error printout that might have been confusing.

Now `make acceptance` passes for me 😄  