### PR TITLE
Use ROBOT_HELM_PATH for completion tests

### DIFF
--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -25,8 +25,9 @@ set -x
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 BINARY_NAME=helm
-BINARY_PATH_DOCKER=${SCRIPT_DIR}/../../../helm/_dist/linux-amd64
-BINARY_PATH_LOCAL=${SCRIPT_DIR}/../../../helm/bin
+BINARY_ROOT=${ROBOT_HELM_PATH:-${SCRIPT_DIR}/../../../helm/bin}
+BINARY_PATH_DOCKER=${BINARY_ROOT}/../_dist/linux-amd64
+BINARY_PATH_LOCAL=${BINARY_ROOT}
 
 if [ -z $(which docker) ]; then
   echo "Missing 'docker' client which is required for these tests";


### PR DESCRIPTION
If the user sets ROBOT_HELM_PATH to specify the location of the helm
binary to test, the completion tests should also use that binary.

We assume that the _dist/ dir is located one level above the location
specified by ROBOT_HELM_PATH.  This is aligned with the reality of
how Helm is build for development.

Signed-off-by: Marc Khouzam <marc.khouzam@ville.montreal.qc.ca>