### PR TITLE
Push check for Helm v2 into each test suite

### DIFF
--- a/kubernetes_versions.robot
+++ b/kubernetes_versions.robot
@@ -10,6 +10,7 @@ Documentation     Verify Helm functionality on multiple Kubernetes versions.
 ...                  export KIND_CLUSTER_1_15_0="helm-ac-keepalive-1.15.0"
 ...
 Library           String
+Library           OperatingSystem
 Library           lib/Kind.py
 Library           lib/Kubectl.py
 Library           lib/Helm.py
@@ -25,6 +26,8 @@ Helm works with Kubernetes 1.15.0
 
 *** Keyword ***
 Test Helm on Kubernetes version
+    Environment Variable Should Be Set  ROBOT_HELM_V3  Helm v2 not supported. Skipping test.
+
     [Arguments]    ${kube_version}
     Create test cluster with kube version    ${kube_version}
 

--- a/kubernetes_versions.robot
+++ b/kubernetes_versions.robot
@@ -26,7 +26,8 @@ Helm works with Kubernetes 1.15.0
 
 *** Keyword ***
 Test Helm on Kubernetes version
-    Environment Variable Should Be Set  ROBOT_HELM_V3  Helm v2 not supported. Skipping test.
+    ${helm_version} =  Get Environment Variable  ROBOT_HELM_V3  "v2"
+    Pass Execution If  ${helm_version} == 'v2'  Helm v2 not supported. Skipping test.
 
     [Arguments]    ${kube_version}
     Create test cluster with kube version    ${kube_version}

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -47,11 +47,11 @@ export XDG_CACHE_HOME=${ROBOT_HELM_HOME_DIR}/cache && mkdir -p ${XDG_CACHE_HOME}
 export XDG_CONFIG_HOME=${ROBOT_HELM_HOME_DIR}/config && mkdir -p ${XDG_CONFIG_HOME}
 export XDG_DATA_HOME=${ROBOT_HELM_HOME_DIR}/data && mkdir -p ${XDG_DATA_HOME}
 
-# We only support helm v3 at this time.
+# We fully support helm v3 and partially support helm v2 at this time.
 # To figure out which version of helm is used, we run 'helm version'
 # with the -c flag which is only supported in helm v2; if we get an
 # error, it means we are running helm v3, if we don't get an error,
-# it's helm v2 and we abort. We want to use the -c flag because if
+# it's helm v2. We want to use the -c flag because if
 # we end up on helm v2 and we don't have that flag, it will try to
 # contact the cluster, which may not be accessible, and the command
 # will timeout.
@@ -61,14 +61,18 @@ export XDG_DATA_HOME=${ROBOT_HELM_HOME_DIR}/data && mkdir -p ${XDG_DATA_HOME}
 # is currently pointing to since we haven't setup the kind cluster yet.
 set +x
 if helm version -c &> /dev/null; then
-    echo "Helm v2 not supported yet!"
-    echo "Please set the ROBOT_HELM_PATH environment variable" \
-         "to the directory where the helm v3 to test can be found."
-    exit 1
+    echo "===================="
+    echo "Running with Helm v2"
+    echo "===================="
+    unset ROBOT_HELM_V3
+else
+    echo "===================="
+    echo "Running with Helm v3"
+    echo "===================="
+    export ROBOT_HELM_V3=1
 fi
 set -x
 
-helm init
 if [[ ! -d ${ROBOT_VENV_DIR} ]]; then
     virtualenv -p $(which python3) ${ROBOT_VENV_DIR}
     pip install ${ROBOT_PY_REQUIRES}

--- a/shells.robot
+++ b/shells.robot
@@ -21,8 +21,11 @@ Documentation     Verify Helm functionality on multiple shells.
 ...               Tests on MacOS will be run if the host running the tests
 ...               is MacOS and has the necessary setup (bash completion and/or zsh)
 ...
+Library           OperatingSystem
 Library           lib/Completion.py
 
 *** Test Cases ***
 Helm shell completion works
+    Environment Variable Should Be Set  ROBOT_HELM_V3  Helm v2 not supported. Skipping test.
+
     Completion.Run all completion tests

--- a/shells.robot
+++ b/shells.robot
@@ -26,6 +26,7 @@ Library           lib/Completion.py
 
 *** Test Cases ***
 Helm shell completion works
-    Environment Variable Should Be Set  ROBOT_HELM_V3  Helm v2 not supported. Skipping test.
+    ${helm_version} =  Get Environment Variable  ROBOT_HELM_V3  "v2"
+    Pass Execution If  ${helm_version} == 'v2'  Helm v2 not supported. Skipping test.
 
     Completion.Run all completion tests


### PR DESCRIPTION
This is to start supporting v2 (#20)

This ignores both test suites and marks them as PASSED.

The first commit of this PR marked the suites as FAILED, but I changed it so that the entire test run wouldn't look failed all the time for v2.