### PR TITLE
Keep track of failures in completion tests

### DIFF
--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -50,8 +50,11 @@ if ! [ -f ${BINARY_PATH_DOCKER}/${BINARY_NAME} ]; then
 fi
 cp ${BINARY_PATH_DOCKER}/${BINARY_NAME} ${COMP_DIR}
 
-# Now run all tests, even if there is a failure
+# Now run all tests, even if there is a failure.
+# But remember if there was any failure to report it at the end.
 set +e
+GOT_FAILURE=0
+trap "GOT_FAILURE=1" ERR
 
 ########################################
 # Bash 4 completion tests
@@ -133,3 +136,6 @@ if [ "$(uname)" == "Darwin" ]; then
       PATH=${BINARY_PATH_LOCAL}:$PATH zsh -c "source ${COMP_SCRIPT}"
    fi
 fi
+
+# Indicate if anything failed during the run
+exit ${GOT_FAILURE}


### PR DESCRIPTION
If a failure happens in some tests, we want to continue running all
other tests, but we also want to report FAIL at the very end.
This commit remembers if a failure happened an uses that knowledge for
the final exit code.