### PR TITLE
Uses testscases instead of keywords

### DIFF
--- a/lib/Sh.py
+++ b/lib/Sh.py
@@ -18,10 +18,10 @@ class Sh(common.CommandRunner):
     def Run(self, cmd):
         self.run_command(self.wrap(cmd))
 
-    def Pass(self, cmd):
+    def should_pass(self, cmd):
         self.Run(cmd)
         self.return_code_should_be(0)
 
-    def Fail(self, cmd):
+    def should_fail(self, cmd):
         self.Run(cmd)
         self.return_code_should_not_be(0)

--- a/lib/Sh.py
+++ b/lib/Sh.py
@@ -1,3 +1,18 @@
+#
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import common
 from Kind import kind_auth_wrap

--- a/lib/Sh.py
+++ b/lib/Sh.py
@@ -2,7 +2,7 @@ import os
 import common
 from Kind import kind_auth_wrap
 
-needs_cluster = True
+needs_cluster = False
 
 class Sh(common.CommandRunner):
     def require_cluster(self, require):

--- a/repos.robot
+++ b/repos.robot
@@ -1,39 +1,30 @@
 *** Settings ***
-Documentation     Verify Helm functionality that does not require a kubernetes cluster.
+Documentation     Verify helm repo commands work as expected.
 ...
-Library           String
 Library           lib/Sh.py
 
 *** Test Cases ***
-Helm repo commands work
-    Verify repo commands work as expected
-
-*** Keyword ***
-Verify repo commands work as expected
-    Sh.Require cluster  False
-
-    # No repos provisioned yet
+No repos provisioned yet
     Sh.Fail  helm repo list
-    # Make sure error message is appropriate
     Sh.Output contains  Error: no repositories
 
-    # Add valid repo
+Add a first valid repo
     Sh.Pass  helm repo add gitlab https://charts.gitlab.io
     Sh.Output contains  "gitlab" has been added to your repositories
 
-    # Add invalid repo without protocol
+Add invalid repo without protocol
     Sh.Fail  helm repo add invalid notAValidURL
     Sh.Output contains  Error: could not find protocol handler
 
-    # Add invalid repo with protocol
+Add invalid repo with protocol
     Sh.Fail  helm repo add invalid https://example.com
     Sh.Output contains  Error: looks like "https://example.com" is not a valid chart repository or cannot be reached
 
-    # Add a second valid repo
+Add a second valid repo
     Sh.Pass  helm repo add jfrog https://charts.jfrog.io
     Sh.Output contains  "jfrog" has been added to your repositories
 
-    # Checkout output of repo list
+Check output of repo list
     Sh.Pass  helm repo list
     Sh.Output contains  gitlab
     Sh.Output contains  https://charts.gitlab.io
@@ -41,39 +32,39 @@ Verify repo commands work as expected
     Sh.Output contains  https://charts.jfrog.io
     Sh.Output does not contain  invalid
 
-    # Make sure both repos get updated
+Make sure both repos get updated
     Sh.Pass  helm repo update
     Sh.Output contains  Successfully got an update from the "gitlab" chart repository
     Sh.Output contains  Successfully got an update from the "jfrog" chart repository
     Sh.Output contains  Update Complete. ⎈ Happy Helming!⎈
 
-    # Try to remove inexistant repo
+Try to remove inexistant repo
     Sh.Fail  helm repo remove badname
     Sh.Output contains  Error: no repo named "badname" found
 
-    # Remove a repo
+Remove a repo
     Sh.Pass  helm repo remove gitlab
     Sh.Output contains  "gitlab" has been removed from your repositories
 
-    # Make sure repo update will only update the remaining repo
+Make sure repo update will only update the remaining repo
     Sh.Pass  helm repo update
     Sh.Output contains  Successfully got an update from the "jfrog" chart repository
     Sh.Output contains  Update Complete. ⎈ Happy Helming!⎈
 
-    # Remove an already removed repo
+Try removing an already removed repo
     Sh.Fail  helm repo remove gitlab
     Sh.Output contains  Error: no repo named "gitlab" found
 
-    # Remove last repo
+Remove last repo
     Sh.Pass  helm repo remove jfrog
     Sh.Output contains  "jfrog" has been removed from your repositories
 
-    # Make sure repo update now fails, with a proper message
-    Sh.Fail  helm repo update
-    Sh.Output contains  Error: no repositories found. You must add one before updating
-
-    # No more repos to list
+Check there are no more repos
     Sh.Fail  helm repo list
     Sh.Output contains  Error: no repositories to show
+
+Make sure repo update now fails, with a proper message
+    Sh.Fail  helm repo update
+    Sh.Output contains  Error: no repositories found. You must add one before updating
 
 # "helm repo index" should also be tested

--- a/repos.robot
+++ b/repos.robot
@@ -20,27 +20,27 @@ Library           lib/Sh.py
 
 *** Test Cases ***
 No repos provisioned yet
-    Should Fail  helm repo list
+    Should fail  helm repo list
     Output contains  Error: no repositories
 
 Add a first valid repo
-    Should Pass  helm repo add gitlab https://charts.gitlab.io
+    Should pass  helm repo add gitlab https://charts.gitlab.io
     Output contains  "gitlab" has been added to your repositories
 
 Add invalid repo without protocol
-    Should Fail  helm repo add invalid notAValidURL
+    Should fail  helm repo add invalid notAValidURL
     Output contains  Error: could not find protocol handler
 
 Add invalid repo with protocol
-    Should Fail  helm repo add invalid https://example.com
+    Should fail  helm repo add invalid https://example.com
     Output contains  Error: looks like "https://example.com" is not a valid chart repository or cannot be reached
 
 Add a second valid repo
-    Should Pass  helm repo add jfrog https://charts.jfrog.io
+    Should pass  helm repo add jfrog https://charts.jfrog.io
     Output contains  "jfrog" has been added to your repositories
 
 Check output of repo list
-    Should Pass  helm repo list
+    Should pass  helm repo list
     Output contains  gitlab
     Output contains  https://charts.gitlab.io
     Output contains  jfrog
@@ -48,38 +48,38 @@ Check output of repo list
     Output does not contain  invalid
 
 Make sure both repos get updated
-    Should Pass  helm repo update
+    Should pass  helm repo update
     Output contains  Successfully got an update from the "gitlab" chart repository
     Output contains  Successfully got an update from the "jfrog" chart repository
     Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try to remove inexistant repo
-    Should Fail  helm repo remove badname
+    Should fail  helm repo remove badname
     Output contains  Error: no repo named "badname" found
 
 Remove a repo
-    Should Pass  helm repo remove gitlab
+    Should pass  helm repo remove gitlab
     Output contains  "gitlab" has been removed from your repositories
 
 Make sure repo update will only update the remaining repo
-    Should Pass  helm repo update
+    Should pass  helm repo update
     Output contains  Successfully got an update from the "jfrog" chart repository
     Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try removing an already removed repo
-    Should Fail  helm repo remove gitlab
+    Should fail  helm repo remove gitlab
     Output contains  Error: no repo named "gitlab" found
 
 Remove last repo
-    Should Pass  helm repo remove jfrog
+    Should pass  helm repo remove jfrog
     Output contains  "jfrog" has been removed from your repositories
 
 Check there are no more repos
-    Should Fail  helm repo list
+    Should fail  helm repo list
     Output contains  Error: no repositories to show
 
 Make sure repo update now fails, with a proper message
-    Should Fail  helm repo update
+    Should fail  helm repo update
     Output contains  Error: no repositories found. You must add one before updating
 
 # "helm repo index" should also be tested

--- a/repos.robot
+++ b/repos.robot
@@ -5,66 +5,66 @@ Library           lib/Sh.py
 
 *** Test Cases ***
 No repos provisioned yet
-    Sh.Fail  helm repo list
-    Sh.Output contains  Error: no repositories
+    Should Fail  helm repo list
+    Output contains  Error: no repositories
 
 Add a first valid repo
-    Sh.Pass  helm repo add gitlab https://charts.gitlab.io
-    Sh.Output contains  "gitlab" has been added to your repositories
+    Should Pass  helm repo add gitlab https://charts.gitlab.io
+    Output contains  "gitlab" has been added to your repositories
 
 Add invalid repo without protocol
-    Sh.Fail  helm repo add invalid notAValidURL
-    Sh.Output contains  Error: could not find protocol handler
+    Should Fail  helm repo add invalid notAValidURL
+    Output contains  Error: could not find protocol handler
 
 Add invalid repo with protocol
-    Sh.Fail  helm repo add invalid https://example.com
-    Sh.Output contains  Error: looks like "https://example.com" is not a valid chart repository or cannot be reached
+    Should Fail  helm repo add invalid https://example.com
+    Output contains  Error: looks like "https://example.com" is not a valid chart repository or cannot be reached
 
 Add a second valid repo
-    Sh.Pass  helm repo add jfrog https://charts.jfrog.io
-    Sh.Output contains  "jfrog" has been added to your repositories
+    Should Pass  helm repo add jfrog https://charts.jfrog.io
+    Output contains  "jfrog" has been added to your repositories
 
 Check output of repo list
-    Sh.Pass  helm repo list
-    Sh.Output contains  gitlab
-    Sh.Output contains  https://charts.gitlab.io
-    Sh.Output contains  jfrog
-    Sh.Output contains  https://charts.jfrog.io
-    Sh.Output does not contain  invalid
+    Should Pass  helm repo list
+    Output contains  gitlab
+    Output contains  https://charts.gitlab.io
+    Output contains  jfrog
+    Output contains  https://charts.jfrog.io
+    Output does not contain  invalid
 
 Make sure both repos get updated
-    Sh.Pass  helm repo update
-    Sh.Output contains  Successfully got an update from the "gitlab" chart repository
-    Sh.Output contains  Successfully got an update from the "jfrog" chart repository
-    Sh.Output contains  Update Complete. ⎈ Happy Helming!⎈
+    Should Pass  helm repo update
+    Output contains  Successfully got an update from the "gitlab" chart repository
+    Output contains  Successfully got an update from the "jfrog" chart repository
+    Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try to remove inexistant repo
-    Sh.Fail  helm repo remove badname
-    Sh.Output contains  Error: no repo named "badname" found
+    Should Fail  helm repo remove badname
+    Output contains  Error: no repo named "badname" found
 
 Remove a repo
-    Sh.Pass  helm repo remove gitlab
-    Sh.Output contains  "gitlab" has been removed from your repositories
+    Should Pass  helm repo remove gitlab
+    Output contains  "gitlab" has been removed from your repositories
 
 Make sure repo update will only update the remaining repo
-    Sh.Pass  helm repo update
-    Sh.Output contains  Successfully got an update from the "jfrog" chart repository
-    Sh.Output contains  Update Complete. ⎈ Happy Helming!⎈
+    Should Pass  helm repo update
+    Output contains  Successfully got an update from the "jfrog" chart repository
+    Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try removing an already removed repo
-    Sh.Fail  helm repo remove gitlab
-    Sh.Output contains  Error: no repo named "gitlab" found
+    Should Fail  helm repo remove gitlab
+    Output contains  Error: no repo named "gitlab" found
 
 Remove last repo
-    Sh.Pass  helm repo remove jfrog
-    Sh.Output contains  "jfrog" has been removed from your repositories
+    Should Pass  helm repo remove jfrog
+    Output contains  "jfrog" has been removed from your repositories
 
 Check there are no more repos
-    Sh.Fail  helm repo list
-    Sh.Output contains  Error: no repositories to show
+    Should Fail  helm repo list
+    Output contains  Error: no repositories to show
 
 Make sure repo update now fails, with a proper message
-    Sh.Fail  helm repo update
-    Sh.Output contains  Error: no repositories found. You must add one before updating
+    Should Fail  helm repo update
+    Output contains  Error: no repositories found. You must add one before updating
 
 # "helm repo index" should also be tested

--- a/repos.robot
+++ b/repos.robot
@@ -1,3 +1,18 @@
+#
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 *** Settings ***
 Documentation     Verify helm repo commands work as expected.
 ...


### PR DESCRIPTION
As I understand the Robot Framework a bit better, I realized that Robot will fail a testcase after the first keyword failure; on the other hand Robot will run all test cases, even after one of them fails.

Therefore, this commit splits up the single test for the `helm repo` command into multiple logical test cases. This allows all tests to be run even when one of them fails, and provides a much richer feedback on the state of regressions, when there are failures.
