### PR TITLE
Add completion testing for zsh on alpine

### DIFF
--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -106,6 +106,21 @@ docker run --rm \
            ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
 
 ########################################
+# Zsh alpine/busybox completion tests
+# https://github.com/helm/helm/pull/6327
+########################################
+ZSH_IMAGE=completion-zsh-alpine
+
+echo;echo;
+docker build -t ${ZSH_IMAGE} - <<- EOF
+   FROM alpine
+   RUN apk update && apk add zsh
+EOF
+docker run --rm \
+           -v ${COMP_DIR}:${COMP_DIR} -v ${COMP_DIR}/${BINARY_NAME}:/bin/${BINARY_NAME} \
+           ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
+
+########################################
 # MacOS completion tests
 ########################################
 # Since we can't use Docker to test MacOS,


### PR DESCRIPTION
Completion did not work for zsh on alpine, so let's test it explicitly.

The problem was reported in https://github.com/helm/helm/pull/6327 for v2 but applies to v3 as well.  

These new tests will only pass once this is fixed in v3 with PR https://github.com/helm/helm/pull/6340

