### PR TITLE
Have repos.robot check for helm v2

### DIFF
--- a/testsuites/repos.robot
+++ b/testsuites/repos.robot
@@ -16,30 +16,37 @@
 *** Settings ***
 Documentation     Verify helm repo commands work as expected.
 ...
+Library           OperatingSystem
 Library           ../lib/Sh.py
 
 *** Test Cases ***
 No repos provisioned yet
+    Check helm version
     Should fail  helm repo list
     Output contains  Error: no repositories
 
 Add a first valid repo
+    Check helm version
     Should pass  helm repo add gitlab https://charts.gitlab.io
     Output contains  "gitlab" has been added to your repositories
 
 Add invalid repo without protocol
+    Check helm version
     Should fail  helm repo add invalid notAValidURL
     Output contains  Error: could not find protocol handler
 
 Add invalid repo with protocol
+    Check helm version
     Should fail  helm repo add invalid https://example.com
     Output contains  Error: looks like "https://example.com" is not a valid chart repository or cannot be reached
 
 Add a second valid repo
+    Check helm version
     Should pass  helm repo add jfrog https://charts.jfrog.io
     Output contains  "jfrog" has been added to your repositories
 
 Check output of repo list
+    Check helm version
     Should pass  helm repo list
     Output contains  gitlab
     Output contains  https://charts.gitlab.io
@@ -48,38 +55,51 @@ Check output of repo list
     Output does not contain  invalid
 
 Make sure both repos get updated
+    Check helm version
     Should pass  helm repo update
     Output contains  Successfully got an update from the "gitlab" chart repository
     Output contains  Successfully got an update from the "jfrog" chart repository
     Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try to remove inexistant repo
+    Check helm version
     Should fail  helm repo remove badname
     Output contains  Error: no repo named "badname" found
 
 Remove a repo
+    Check helm version
     Should pass  helm repo remove gitlab
     Output contains  "gitlab" has been removed from your repositories
 
 Make sure repo update will only update the remaining repo
+    Check helm version
     Should pass  helm repo update
     Output contains  Successfully got an update from the "jfrog" chart repository
     Output contains  Update Complete. ⎈ Happy Helming!⎈
 
 Try removing an already removed repo
+    Check helm version
     Should fail  helm repo remove gitlab
     Output contains  Error: no repo named "gitlab" found
 
 Remove last repo
+    Check helm version
     Should pass  helm repo remove jfrog
     Output contains  "jfrog" has been removed from your repositories
 
 Check there are no more repos
+    Check helm version
     Should fail  helm repo list
     Output contains  Error: no repositories to show
 
 Make sure repo update now fails, with a proper message
+    Check helm version
     Should fail  helm repo update
     Output contains  Error: no repositories found. You must add one before updating
 
 # "helm repo index" should also be tested
+
+*** Keyword ***
+Check helm version
+    ${helm_version} =  Get Environment Variable  ROBOT_HELM_V3  "v2"
+    Pass Execution If  ${helm_version} == 'v2'  Helm v2 not supported. Skipping test.


### PR DESCRIPTION
The repos.robot tests were missing a check for helm v2, which will cause them to be skipped.