### PR TITLE
Mark test as passing once fixed in helm repo

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -128,7 +128,7 @@ fi
 
 # Completion of commands while using flags
 _completionTests_verifyCompletion "helm --kube-context prod sta" "status"
-_completionTests_verifyCompletion ZFAIL "helm --kubeconfig=/tmp/config lis" "list"
+_completionTests_verifyCompletion "helm --kubeconfig=/tmp/config lis" "list"
 _completionTests_verifyCompletion ZFAIL "helm get hooks --kubec" "--kubeconfig= --kubeconfig"
 if [ ! -z ${ROBOT_HELM_V3} ]; then
     _completionTests_verifyCompletion "helm --namespace mynamespace get h" "hooks"


### PR DESCRIPTION
I'm submitting a fix to helm for this failing test.
This commit marks the test as passing.

Should only be merged once the corresponding fix is merged in Helm