### PR TITLE
Add tests for dynamic completion of global flags

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -156,3 +156,22 @@ _completionTests_verifyCompletion "helm plugin remove " "template push push-arti
 _completionTests_verifyCompletion "helm plugin remove pu" "push push-artifactory"
 _completionTests_verifyCompletion "helm plugin update " "template push push-artifactory"
 _completionTests_verifyCompletion "helm plugin update pus" "push push-artifactory"
+
+# For the global --kube-context flag
+_completionTests_verifyCompletion "helm --kube-context " "dev1 dev2 accept prod"
+_completionTests_verifyCompletion ZFAIL "helm --kube-context=" "dev1 dev2 accept prod"
+_completionTests_verifyCompletion "helm upgrade --kube-context " "dev1 dev2 accept prod"
+_completionTests_verifyCompletion "helm upgrade --kube-context d" "dev1 dev2"
+# For the global --namespace flag
+if [ ! -z ${ROBOT_HELM_V3} ]; then
+    _completionTests_verifyCompletion "helm --namespace " "casterly-rock white-harbor winterfell"
+    _completionTests_verifyCompletion "helm --namespace w" "white-harbor winterfell"
+    _completionTests_verifyCompletion ZFAIL "helm --namespace=w" "white-harbor winterfell"
+    _completionTests_verifyCompletion "helm upgrade --namespace " "casterly-rock white-harbor winterfell"
+
+    # With override flags
+    _completionTests_verifyCompletion "helm --kubeconfig myconfig --namespace " "meereen myr volantis"
+    _completionTests_verifyCompletion "helm --kubeconfig=myconfig --namespace " "meereen myr volantis"
+    _completionTests_verifyCompletion "helm --kube-context mycontext --namespace " "braavos old-valyria yunkai"
+    _completionTests_verifyCompletion "helm --kube-context=mycontext --namespace " "braavos old-valyria yunkai"
+fi

--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -19,6 +19,8 @@
 
 source /tmp/helm-acceptance-shell-completion-tests/lib/completionTests-base.sh
 
+export PATH=/tmp/helm-acceptance-shell-completion-tests/bin:$PATH
+
 # Don't use the new source <() form as it does not work with bash v3
 source /dev/stdin <<- EOF
    $(helm completion $SHELL_TYPE)

--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -50,6 +50,34 @@ if ! [ -f ${BINARY_PATH_DOCKER}/${BINARY_NAME} ]; then
 fi
 cp ${BINARY_PATH_DOCKER}/${BINARY_NAME} ${COMP_DIR}/bin
 
+# kubectl stub
+cat > ${COMP_DIR}/bin/kubectl << EOF
+#!/bin/sh
+# return some fake namespaces
+if echo "\$*" | grep -q namespace; then
+    if echo "\$*" | grep -q -- --context; then
+        echo "braavos old-valyria yunkai"
+        exit 0
+    fi
+
+    if echo "\$*" | grep -q -- --kubeconfig; then
+        echo "meereen myr volantis"
+        exit 0
+    fi
+
+    echo "casterly-rock white-harbor winterfell"
+    exit 0
+fi
+
+# return some fake contexts
+if echo "\$*" | grep -q context; then
+    echo "accept dev1 dev2 prod"
+    exit 0
+fi
+EOF
+chmod a+x ${COMP_DIR}/bin/kubectl
+cat ${COMP_DIR}/bin/kubectl
+
 # Now run all tests, even if there is a failure.
 # But remember if there was any failure to report it at the end.
 set +e


### PR DESCRIPTION
This PR adds tests for the dynamic completion of global flags, as proposed in https://github.com/helm/helm/pull/6408

As the completion function in Helm uses `kubectl` and contacts the cluster, I chose to write a mini stub of `kubectl` to avoid having to have a full `kubectl` setup in the completion tests.

This should only be merged once https://github.com/helm/helm/pull/6408 is merged.