### PR TITLE
Improve error reporting

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -154,3 +154,7 @@ _completionTests_verifyCompletion "helm plugin remove " "template push push-arti
 _completionTests_verifyCompletion "helm plugin remove pu" "push push-artifactory"
 _completionTests_verifyCompletion "helm plugin update " "template push push-artifactory"
 _completionTests_verifyCompletion "helm plugin update pus" "push push-artifactory"
+
+# This must be the last call.  It allows to exit with an exit code
+# that reflects the final status of all the tests.
+_completionTests_exit

--- a/scripts/completion-tests/lib/completionTests-base.sh
+++ b/scripts/completion-tests/lib/completionTests-base.sh
@@ -53,6 +53,7 @@ _completionTests_verifyCompletion() {
 
    local cmdLine=$1
    local expected=$2
+   local currentFailure=0
 
    result=$(_completionTests_complete "${cmdLine}")
 
@@ -69,6 +70,7 @@ _completionTests_verifyCompletion() {
            ([ $expectedFailure = "ZFAIL" ] && [ $SHELL_TYPE = "zsh" ]); then
       if [ "$result" = "$expected" ]; then
          _completionTests_TEST_FAILED=1
+         currentFailure=1
          echo "UNEXPECTED SUCCESS: \"$cmdLine\" completes to \"$resultOut\""
       else
          echo "$expectedFailure: \"$cmdLine\" should complete to \"$expected\" but we got \"$resultOut\""
@@ -77,12 +79,11 @@ _completionTests_verifyCompletion() {
       echo "SUCCESS: \"$cmdLine\" completes to \"$resultOut\""
    else
       _completionTests_TEST_FAILED=1
+      currentFailure=1
       echo "FAIL: \"$cmdLine\" should complete to \"$expected\" but we got \"$result\""
    fi
 
-   # Return the global result each time.  This allows for the very last call to
-   # this method to return the correct success or failure code for the entire script
-   return $_completionTests_TEST_FAILED
+   return $currentFailure
 }
 
 _completionTests_disable_sort() {
@@ -136,6 +137,12 @@ _completionTests_complete() {
 
    # Return the result of the completion.
    echo "${COMPREPLY[@]}"
+}
+
+_completionTests_exit() {
+   # Return the global result each time.  This allows for the very last call to
+   # this method to return the correct success or failure code for the entire script
+   return $_completionTests_TEST_FAILED
 }
 
 # compopt, which is only available for bash 4, I believe,


### PR DESCRIPTION
To avoid making the user have to call a generic method at the very
end of the tests to get the final exit code, I had put the exit code
in the return call of _completionTests_verifyCompletion().

This strategy turns out to be brittle because if the test file ends
with a statement such as

if [ ! -z ${ROBOT_HELM_V3} ]; then
    _completionTests_verifyCompletion "helm comm" ""
fi

and that the execution does not enter the if, then the error code will
be the one of the if statement (success) and not the one of
_completionTests_verifyCompletion() (global test status).

So this commit falls back to the requirement of calling an exit
function at the end of the tests (_completionTests_exit()).
With this requirement, it is no longer needed for
_completionTests_verifyCompletion() to return the global test status.
Instead, it now returns the result of the current completion
verification which allows to take action on that result if so desired,
which couldn't be done before.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>