### PR TITLE
Handle binary in a dedicated directory

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -19,6 +19,8 @@
 
 source /tmp/helm-acceptance-shell-completion-tests/lib/completionTests-base.sh
 
+export PATH=/tmp/helm-acceptance-shell-completion-tests/bin:$PATH
+
 # Don't use the new source <() form as it does not work with bash v3
 source /dev/stdin <<- EOF
    $(helm completion $SHELL_TYPE)


### PR DESCRIPTION
Small change that will allow for more flexibility for new tests that will need to move helm around.

It's isolated to the completion tests so I'll merge right away.