### PR TITLE
Test with different binary name

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -207,46 +207,50 @@ trap "rm -rf ${TMP_HELM_DIR}" EXIT
 mkdir -p $TMP_HELM_DIR
 HELM_DIR=$(dirname $(which helm))
 cp $HELM_DIR/helm $TMP_HELM_DIR/helm
-# Create aliases to helm
-# This alias will be created after the variable is expanded
-alias helmAlias="${TMP_HELM_DIR}/helm"
-# This alias will be created without expanding the variable (because of single quotes)
-alias helmAliasWithVar='${TMP_HELM_DIR}/helm'
 
-# Hook these new aliases to the helm completion function.
-# Only bash needs this, zsh does it automatically.
-if [ $SHELL_TYPE == bash ]; then
+# Testing with shell aliases is only applicable to bash.
+# Zsh replaces the alias before calling the completion function,
+# so it does not make sense to try zsh completion with an alias.
+if [ "$SHELL_TYPE" = bash ]; then
+
+    # Create aliases to helm
+    # This alias will be created after the variable is expanded
+    alias helmAlias="${TMP_HELM_DIR}/helm"
+    # This alias will be created without expanding the variable (because of single quotes)
+    alias helmAliasWithVar='${TMP_HELM_DIR}/helm'
+
+    # Hook these new aliases to the helm completion function.
     complete -o default -F $(_completionTests_findCompletionFunction helm) helmAlias
     complete -o default -F $(_completionTests_findCompletionFunction helm) helmAliasWithVar
-fi
 
-# Now make 'helm' unavailable to make sure it can't be used by
-# the dynamic completion, which should instead use the helm
-# specified in the completion call.
-alias helm=echo
+    # Now make 'helm' unavailable to make sure it can't be used by
+    # the dynamic completion, which should instead use the helm
+    # specified in the completion call.
+    alias helm=echo
 
-# Completion with normal alias
-_completionTests_verifyCompletion "helmAlias lis" "list"
-_completionTests_verifyCompletion "helmAlias completion z" "zsh"
-_completionTests_verifyCompletion ZFAIL "helmAlias --kubecon" "--kubeconfig= --kubeconfig"
-_completionTests_verifyCompletion ZFAIL "helmAlias get hooks --kubec" "--kubeconfig= --kubeconfig"
-_completionTests_verifyCompletion "helmAlias repo remove test" "test1 test2"
-_completionTests_verifyCompletion "helmAlias plugin update pus" "push push-artifactory"
-_completionTests_verifyCompletion "helmAlias upgrade --kube-context d" "dev1 dev2"
-if [ ! -z ${ROBOT_HELM_V3} ]; then
-    _completionTests_verifyCompletion "helmAlias --kube-context=mycontext --namespace " "braavos old-valyria yunkai"
-fi
+    # Completion with normal alias
+    _completionTests_verifyCompletion "helmAlias lis" "list"
+    _completionTests_verifyCompletion "helmAlias completion z" "zsh"
+    _completionTests_verifyCompletion "helmAlias --kubecon" "--kubeconfig= --kubeconfig"
+    _completionTests_verifyCompletion "helmAlias get hooks --kubec" "--kubeconfig= --kubeconfig"
+    _completionTests_verifyCompletion "helmAlias repo remove test" "test1 test2"
+    _completionTests_verifyCompletion "helmAlias plugin update pus" "push push-artifactory"
+    _completionTests_verifyCompletion "helmAlias upgrade --kube-context d" "dev1 dev2"
+    if [ ! -z ${ROBOT_HELM_V3} ]; then
+        _completionTests_verifyCompletion "helmAlias --kube-context=mycontext --namespace " "braavos old-valyria yunkai"
+    fi
 
-# Completion with alias that contains a variable
-_completionTests_verifyCompletion "helmAliasWithVar lis" "list"
-_completionTests_verifyCompletion "helmAliasWithVar completion z" "zsh"
-_completionTests_verifyCompletion ZFAIL "helmAliasWithVar --kubecon" "--kubeconfig= --kubeconfig"
-_completionTests_verifyCompletion ZFAIL "helmAliasWithVar get hooks --kubec" "--kubeconfig= --kubeconfig"
-_completionTests_verifyCompletion "helmAliasWithVar repo remove test" "test1 test2"
-_completionTests_verifyCompletion "helmAliasWithVar plugin update pus" "push push-artifactory"
-_completionTests_verifyCompletion "helmAliasWithVar upgrade --kube-context d" "dev1 dev2"
-if [ ! -z ${ROBOT_HELM_V3} ]; then
-    _completionTests_verifyCompletion "helmAliasWithVar --kube-context=mycontext --namespace " "braavos old-valyria yunkai"
+    # Completion with alias that contains a variable
+    _completionTests_verifyCompletion "helmAliasWithVar lis" "list"
+    _completionTests_verifyCompletion "helmAliasWithVar completion z" "zsh"
+    _completionTests_verifyCompletion "helmAliasWithVar --kubecon" "--kubeconfig= --kubeconfig"
+    _completionTests_verifyCompletion "helmAliasWithVar get hooks --kubec" "--kubeconfig= --kubeconfig"
+    _completionTests_verifyCompletion "helmAliasWithVar repo remove test" "test1 test2"
+    _completionTests_verifyCompletion "helmAliasWithVar plugin update pus" "push push-artifactory"
+    _completionTests_verifyCompletion "helmAliasWithVar upgrade --kube-context d" "dev1 dev2"
+    if [ ! -z ${ROBOT_HELM_V3} ]; then
+        _completionTests_verifyCompletion "helmAliasWithVar --kube-context=mycontext --namespace " "braavos old-valyria yunkai"
+    fi
 fi
 
 # Completion with absolute path
@@ -277,9 +281,12 @@ cd - >/dev/null
 
 # Completion with a different name for helm
 mv $TMP_HELM_DIR/helm $TMP_HELM_DIR/myhelm
-if [ $SHELL_TYPE == bash ]; then
-    complete -o default -F $(_completionTests_findCompletionFunction helm) myhelm
-fi
+
+# Generating the completion script using the new binary name
+# should make completion work for that binary name
+source /dev/stdin <<- EOF
+   $(${TMP_HELM_DIR}/myhelm completion $SHELL_TYPE)
+EOF
 _completionTests_verifyCompletion "$TMP_HELM_DIR/myhelm lis" "list"
 _completionTests_verifyCompletion "$TMP_HELM_DIR/myhelm completion z" "zsh"
 _completionTests_verifyCompletion ZFAIL "$TMP_HELM_DIR/myhelm --kubecon" "--kubeconfig= --kubeconfig"

--- a/scripts/completion-tests/lib/completionTests-base.sh
+++ b/scripts/completion-tests/lib/completionTests-base.sh
@@ -107,7 +107,9 @@ _completionTests_sort() {
 # us to find the existing completion function name.
 _completionTests_findCompletionFunction() {
     binary=$(basename $1)
-    local out=($(complete -p $binary))
+    # The below must work for both bash and zsh
+    # which is why we use grep as complete -p $binary only works for bash
+    local out=($(complete -p | grep ${binary}$))
     local returnNext=0
     for i in ${out[@]}; do
        if [ $returnNext -eq 1 ]; then


### PR DESCRIPTION
This updates the tests for a different helm binary named to test https://github.com/helm/helm/pull/6502

It also fixed a bug in the completion lib for zsh, and removes the zsh alias tests, as they are not applicable.
