### PR TITLE
Simplify python libs by using generic Sh lib

### DIFF
--- a/lib/Helm.py
+++ b/lib/Helm.py
@@ -5,15 +5,7 @@ from Kind import kind_auth_wrap
 TEST_CHARTS_ROOT_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) +'/../testdata/charts')
 
 class Helm(common.CommandRunner):
-    def list_releases(self):
-        cmd = 'helm list'
-        self.run_command(kind_auth_wrap(cmd))
-
     def install_test_chart(self, release_name, test_chart, extra_args):
         chart_path = TEST_CHARTS_ROOT_DIR+'/'+test_chart
         cmd = 'helm install '+release_name+' '+chart_path+' '+extra_args
-        self.run_command(kind_auth_wrap(cmd))
-
-    def delete_release(self, release_name):
-        cmd = 'helm delete '+release_name
         self.run_command(kind_auth_wrap(cmd))

--- a/lib/Kubectl.py
+++ b/lib/Kubectl.py
@@ -2,22 +2,6 @@ import common
 from Kind import kind_auth_wrap
 
 class Kubectl(common.CommandRunner):
-    def get_nodes(self):
-        cmd = 'kubectl get nodes'
-        self.run_command(kind_auth_wrap(cmd))
-
-    def get_pods(self, namespace):
-        cmd = 'kubectl get pods --namespace='+namespace
-        self.run_command(kind_auth_wrap(cmd))
-
-    def get_services(self, namespace):
-        cmd = 'kubectl get services --namespace='+namespace
-        self.run_command(kind_auth_wrap(cmd))
-
-    def get_persistent_volume_claims(self, namespace):
-        cmd = 'kubectl get pvc --namespace='+namespace
-        self.run_command(kind_auth_wrap(cmd))
-
     def service_has_ip(self, namespace, service_name):
         cmd = 'kubectl get services --namespace='+namespace
         cmd += ' | grep '+service_name


### PR DESCRIPTION
This commit replaces the methods of our python libraries that run simple
helm and kubectl methods with there corresponding lib/Sh.py calls.

This makes the code easier to understand as it builds on people's
existing knowledge of helm and kubectl commands.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>