### PR TITLE
Var ROBOT_DEBUG_COMPLETION to allow completion tests to print to console

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -131,5 +131,10 @@ if [[ ! -d ${ROBOT_VENV_DIR} ]]; then
     pip install ${ROBOT_PY_REQUIRES}
 fi
 
+if [ -n "$ROBOT_DEBUG_COMPLETION" ]; then
+    scripts/completion-tests/test-completion.sh
+    exit
+fi
+
 # Run Robot Framework, output
 robot --outputdir=${ROBOT_OUTPUT_DIR} ${SUITES_TO_RUN}

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -113,7 +113,7 @@ export XDG_DATA_HOME=${TMP_DIR}/data && mkdir -p ${XDG_DATA_HOME}
 # contact the cluster, which may not be accessible, and the command
 # will timeout.
 set_shell_debug_level 3
-if helm version -c &> /dev/null; then
+if helm version -c --tls &> /dev/null; then
     echo "===================="
     echo "Running with Helm v2"
     echo "===================="


### PR DESCRIPTION
ROBOT only gives the tester access to the logs at the very end of the test run.  When developping, this can be annoying.  This change, admittedly a hack, allows to debug the completion tests more easily, by running them outside of ROBOT.