### PR TITLE
Print ERROR instead of FAIL

### DIFF
--- a/scripts/completion-tests/lib/completionTests-base.sh
+++ b/scripts/completion-tests/lib/completionTests-base.sh
@@ -80,7 +80,7 @@ _completionTests_verifyCompletion() {
    else
       _completionTests_TEST_FAILED=1
       currentFailure=1
-      echo "FAIL: \"$cmdLine\" should complete to \"$expected\" but we got \"$result\""
+      echo "ERROR: \"$cmdLine\" should complete to \"$expected\" but we got \"$result\""
    fi
 
    return $currentFailure


### PR DESCRIPTION
There are expected failures which print KFAIL, so having the real failures be FAIL makes it more annoying to grep them out.  This PR replaces FAIL with ERROR