### PR TITLE
Support if the help is either stdout or stderr

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -197,7 +197,7 @@ if [ ! -z ${ROBOT_HELM_V3} ]; then
     # Also test that the list of outputs matches what the helm message gives.
     # This is an imperfect way of detecting if the output format list has changed, but
     # the completion wasn't updated to match.
-    outputFormats=$(helm repo list -h | grep -- --output | cut -d: -f2 | cut -d '(' -f1 | sed s/,//g)
+    outputFormats=$(helm repo list -h 2>&1 | grep -- --output | cut -d: -f2 | cut -d '(' -f1 | sed s/,//g)
     _completionTests_verifyCompletion "helm repo list --output " "${outputFormats}"
     _completionTests_verifyCompletion "helm install --output " "${outputFormats}"
     _completionTests_verifyCompletion "helm history -o " "${outputFormats}"


### PR DESCRIPTION
There is a change in Cobra which causes the help message to be printed
to stderr instead of stdout.
See https://github.com/spf13/cobra/pull/922

In preparation for a future upgrade to a new version of Cobra,
this commit allows the tests to support both cases.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>