### PR TITLE
Allow to run Makefile for another directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-SHELL = /bin/bash
+SHELL    = /bin/bash
+ROOT_DIR = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: acceptance
 acceptance:
-	@scripts/acceptance.sh
+	@$(ROOT_DIR)/scripts/acceptance.sh
 
 .PHONY: github-actions-ci
 github-actions-ci:
-	@scripts/github-actions-ci.sh
+	@$(ROOT_DIR)/scripts/github-actions-ci.sh
 
 .PHONY: github-actions-ci-local
 github-actions-ci-local:
 	docker run -it --rm \
-	    -v $(shell pwd):/tmp/acceptance-testing \
+	    -v $(ROOT_DIR):/tmp/acceptance-testing \
 	    -w /tmp/acceptance-testing  \
 	    --privileged -v /var/run/docker.sock:/var/run/docker.sock \
 	    --entrypoint=/bin/bash ubuntu:latest \


### PR DESCRIPTION
It is possible for a user to run make from outside of the
acceptance-testing directory.  For example

$ cd /tmp
$ make -f $GOPATH/src/helm.sh/acceptance-testing/Makefile

To support this, the Makefile must use the ROOT_DIR of where the
Makefile resides, so as to find all other files.

Signed-off-by: Marc Khouzam <marc.khouzam@montreal.ca>