### PR TITLE
Add clean target to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-SHELL = /bin/bash
+SHELL    = /bin/bash
+ROOT_DIR = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: acceptance
 acceptance:
-	@scripts/acceptance.sh
+	@$(ROOT_DIR)/scripts/acceptance.sh
 
 .PHONY: github-actions-ci
 github-actions-ci:
-	@scripts/github-actions-ci.sh
+	@$(ROOT_DIR)/scripts/github-actions-ci.sh
 
 .PHONY: github-actions-ci-local
 github-actions-ci-local:
 	docker run -it --rm \
-	    -v $(shell pwd):/tmp/acceptance-testing \
+	    -v $(ROOT_DIR):/tmp/acceptance-testing \
 	    -w /tmp/acceptance-testing  \
 	    --privileged -v /var/run/docker.sock:/var/run/docker.sock \
 	    --entrypoint=/bin/bash ubuntu:latest \

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ github-actions-ci-local:
 	    --privileged -v /var/run/docker.sock:/var/run/docker.sock \
 	    --entrypoint=/bin/bash ubuntu:latest \
 	    -c 'set +e; scripts/github-actions-ci.sh; echo "Exited $?. (Ctrl+D to exit shell)"; bash'
+
+.PHONY: clean
+clean:
+	/bin/rm -rf $(ROOT_DIR)/.acceptance


### PR DESCRIPTION
The installation of some tools has hard-code paths in them. For example:
```
$ head -1 .acceptance/.venv/bin/robot
#!/Users/marckhouzam/git/acceptance-testing/.acceptance/.venv/bin/python3.7
```
If I want to move the acceptance-testing repo to a new directory on my computer, the installed tools will no longer work due to these hard-coded paths.  The simplest solution is to cleanup and re-install them.

This commit as a 'make clean' target to easily remove the entire .acceptance directory.
