### PR TITLE
Revert "Support if the help is either stdout or stderr (#64)"

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -242,7 +242,7 @@ if [ ! -z ${ROBOT_HELM_V3} ]; then
     # Also test that the list of outputs matches what the helm message gives.
     # This is an imperfect way of detecting if the output format list has changed, but
     # the completion wasn't updated to match.
-    outputFormats=$(helm repo list -h 2>&1 | grep -- --output | cut -d: -f2 | cut -d '(' -f1 | sed s/,//g)
+    outputFormats=$(helm repo list -h | grep -- --output | cut -d: -f2 | cut -d '(' -f1 | sed s/,//g)
     _completionTests_verifyCompletion "helm repo list --output " "${outputFormats}"
     _completionTests_verifyCompletion "helm install --output " "${outputFormats}"
     _completionTests_verifyCompletion "helm history -o " "${outputFormats}"


### PR DESCRIPTION
This reverts commit 187a7742892088cfa7d90afde2387882028b16b2.

Cobra has reverted the change that had the help message go to stderr:
https://github.com/spf13/cobra/pull/1004

Considering what allowed to notice this regression in Cobra was the failure of Helm's acceptance-testing repo, I prefer to continue have the test fail if the help ever goes to stderr.