### PR TITLE
Test kube-context completion without assuming kubectl

### DIFF
--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -70,17 +70,40 @@ else
   cp $(which helm-docker) ${COMP_DIR}/bin/helm
 fi
 
-# kubectl stub
-cat > ${COMP_DIR}/bin/kubectl << EOF
-#!/bin/sh
-# return some fake contexts
-if echo "\$*" | grep -q context; then
-    echo "accept dev1 dev2 prod"
-    exit 0
-fi
+# config file stubs
+cat > ${COMP_DIR}/config.dev1 << EOF
+kind: Config
+apiVersion: v1
+contexts:
+- context:
+  name: dev1
+current-context: dev1
 EOF
-chmod a+x ${COMP_DIR}/bin/kubectl
-cat ${COMP_DIR}/bin/kubectl
+cat > ${COMP_DIR}/config.dev2 << EOF
+kind: Config
+apiVersion: v1
+contexts:
+- context:
+  name: dev2
+current-context: dev2
+EOF
+cat > ${COMP_DIR}/config.accept << EOF
+kind: Config
+apiVersion: v1
+contexts:
+- context:
+  name: accept
+current-context: accept
+EOF
+cat > ${COMP_DIR}/config.prod << EOF
+kind: Config
+apiVersion: v1
+contexts:
+- context:
+  name: prod
+current-context: prod
+EOF
+export KUBECONFIG=${COMP_DIR}/config.dev1:${COMP_DIR}/config.dev2:${COMP_DIR}/config.accept:${COMP_DIR}/config.prod
 
 # Now run all tests, even if there is a failure.
 # But remember if there was any failure to report it at the end.
@@ -103,6 +126,7 @@ docker run --rm \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
+           -e KUBECONFIG=${KUBECONFIG} \
            ${BASH4_IMAGE} bash -c "source ${COMP_SCRIPT}"
 
 ########################################
@@ -128,6 +152,7 @@ docker run --rm \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
+           -e KUBECONFIG=${KUBECONFIG} \
            ${BASH3_IMAGE} bash -c "source ${COMP_SCRIPT}"
 
 ########################################
@@ -146,6 +171,7 @@ docker run --rm \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
+           -e KUBECONFIG=${KUBECONFIG} \
            ${BASH_IMAGE} bash -c "source ${COMP_SCRIPT}"
 
 ########################################
@@ -164,6 +190,7 @@ docker run --rm \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
+           -e KUBECONFIG=${KUBECONFIG} \
            ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
 
 ########################################
@@ -182,6 +209,7 @@ docker run --rm \
            -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
            -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
            -e COMP_DIR=${COMP_DIR} \
+           -e KUBECONFIG=${KUBECONFIG} \
            ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
 
 ########################################


### PR DESCRIPTION
This changes the completion tests for completing the value of the `--kube-context` flag to not assume kubectl.
It must wait until helm completes the `--kube-context` flag in go instead of bash as changed in the following pr https://github.com/helm/helm/pull/7602