### PR TITLE
Add a completion test for the help message

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -182,7 +182,9 @@ fi
 
 # Basic first level commands (static completion)
 _completionTests_verifyCompletion "helm " "$allHelmCommands"
+_completionTests_verifyCompletion "helm help " "$allHelmCommands"
 _completionTests_verifyCompletion "helm sho" "show"
+_completionTests_verifyCompletion "helm help sho" "show"
 _completionTests_verifyCompletion "helm --debug " "$allHelmCommands"
 _completionTests_verifyCompletion "helm --debug sho" "show"
 _completionTests_verifyCompletion "helm -n ns " "$allHelmCommands"


### PR DESCRIPTION
When running
   helm help TAB
all commands should be displayed.

This scenario came close to regressing due to a possible change in Cobra.  This test will allow us to notice quicker if it does.