### PR TITLE
Daemon set assertion should use no of nodes dynamically.

### DIFF
--- a/lib/Kubectl.py
+++ b/lib/Kubectl.py
@@ -2,6 +2,7 @@ import common
 from Kind import kind_auth_wrap
 
 class Kubectl(common.CommandRunner):
+
     def service_has_ip(self, namespace, service_name):
         cmd = 'kubectl get services --namespace='+namespace
         cmd += ' | grep '+service_name
@@ -19,3 +20,8 @@ class Kubectl(common.CommandRunner):
         cmd += ' | grep ^'+pod_prefix+' | awk \'{print $2 "--" $3}\''
         cmd += ' | grep -E "^([1-9][0-9]*)/\\1--Running" | wc -l` == '+num_expected+' ]'
         self.run_command(kind_auth_wrap(cmd))
+
+    def deamon_set_pods_with_prefix(self, namespace,pod_prefix):
+        cmd = 'kubectl get nodes | grep Ready | wc -l'
+        self.run_command(kind_auth_wrap(cmd))
+        self.pods_with_prefix_are_running(namespace, pod_prefix, self.stdout)

--- a/testsuites/kubernetes_versions.robot
+++ b/testsuites/kubernetes_versions.robot
@@ -35,16 +35,14 @@ Suite Setup       Suite Setup
 Suite Teardown    Suite Teardown
 
 *** Test Cases ***
-#Helm works with Kubernetes 1.16.1
-#    Test Helm on Kubernetes version   1.16.1
+Helm works with Kubernetes 1.16.1
+    Test Helm on Kubernetes version   1.16.1
 
 Helm works with Kubernetes 1.15.3
     Test Helm on Kubernetes version   1.15.3
 
-Helm works with Kubernetes 1.14.6
-    Test Helm on Kubernetes version   1.14.6
-
 *** Keyword ***
+
 Test Helm on Kubernetes version
     Require cluster  True
 
@@ -85,7 +83,7 @@ Verify --wait flag works as expected
 
     Kubectl.Pods with prefix are running    default    wait-flag-good-nginx-ext-    3
     Kubectl.Return code should be   0
-    Kubectl.Pods with prefix are running    default    wait-flag-good-nginx-fluentd-es-    1
+    Kubectl.Deamon Set Pods With Prefix    default    wait-flag-good-nginx-fluentd-es-
     Kubectl.Return code should be   0
     Kubectl.Pods with prefix are running    default    wait-flag-good-nginx-v1-    3
     Kubectl.Return code should be   0

--- a/testsuites/kubernetes_versions.robot
+++ b/testsuites/kubernetes_versions.robot
@@ -41,6 +41,9 @@ Helm works with Kubernetes 1.16.1
 Helm works with Kubernetes 1.15.3
     Test Helm on Kubernetes version   1.15.3
 
+Helm works with Kubernetes 1.14.6
+    Test Helm on Kubernetes version   1.14.6
+
 *** Keyword ***
 
 Test Helm on Kubernetes version


### PR DESCRIPTION
#### What happens currently

We create Deamonset resource in the testdata and in test assertion we expect single pod to be deployed in the cluster. 
By default cluster created by `kind`  has only one node, Tests might pass if we have not defined node count while creating cluster.

#### When will this fail 
If we create multi node cluster using (https://kind.sigs.k8s.io/docs/user/quick-start/#multinode-clusters), Our tests would expect to have only one deamonset pod deployed but eventually no of deamonset would be equal to no of pods.