### PR TITLE
Fix completion tests

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -196,13 +196,13 @@ source /dev/stdin <<- EOF
    $(helm completion $SHELL_TYPE)
 EOF
 
-allHelmCommands="completion create dependency env 2to3 get history install lint list package plugin pull push push-artifactory repo rollback search show status template test uninstall upgrade verify version"
+allHelmCommands="completion create dependency env 2to3 help get history install lint list package plugin pull push push-artifactory repo rollback search show status template test uninstall upgrade verify version"
 if [ "$SHELL_TYPE" = bash ]; then
-    allHelmGlobalFlags="--add-dir-header --alsologtostderr --debug --kube-apiserver --kube-apiserver= --kube-context --kube-context= --kube-token --kube-token= --kubeconfig --kubeconfig= --log-backtrace-at --log-backtrace-at= --log-dir --log-dir= --log-file --log-file-max-size --log-file-max-size= --log-file= --logtostderr --namespace --namespace= --registry-config --registry-config= --repository-cache --repository-cache= --repository-config --repository-config= --skip-headers --skip-log-headers --stderrthreshold --stderrthreshold= --v --v= --vmodule --vmodule= -n -v"
-    allHelmLongFlags="--add-dir-header --alsologtostderr --debug --kube-apiserver --kube-apiserver= --kube-context --kube-context= --kube-token --kube-token= --kubeconfig --kubeconfig= --log-backtrace-at --log-backtrace-at= --log-dir --log-dir= --log-file --log-file-max-size --log-file-max-size= --log-file= --logtostderr --namespace --namespace= --registry-config --registry-config= --repository-cache --repository-cache= --repository-config --repository-config= --skip-headers --skip-log-headers --stderrthreshold --stderrthreshold= --v --v= --vmodule --vmodule="
+    allHelmGlobalFlags="--debug --kube-apiserver --kube-apiserver= --kube-as-group --kube-as-group= --kube-as-user --kube-as-user= --kube-ca-file --kube-ca-file= --kube-context --kube-context= --kube-token --kube-token= --kubeconfig --kubeconfig= --namespace --namespace= --registry-config --registry-config= --repository-cache --repository-cache= --repository-config --repository-config= -n"
+    allHelmLongFlags="--debug --kube-apiserver --kube-apiserver= --kube-as-group --kube-as-group= --kube-as-user --kube-as-user= --kube-ca-file --kube-ca-file= --kube-context --kube-context= --kube-token --kube-token= --kubeconfig --kubeconfig= --namespace --namespace= --registry-config --registry-config= --repository-cache --repository-cache= --repository-config --repository-config="
 else
-    allHelmGlobalFlags="--add-dir-header --alsologtostderr --debug --kube-apiserver --kube-apiserver --kube-apiserver --kube-context --kube-context --kube-context --kube-token --kube-token --kube-token --kubeconfig --kubeconfig --kubeconfig --log-backtrace-at --log-backtrace-at --log-backtrace-at --log-dir --log-dir --log-dir --log-file --log-file --log-file --log-file-max-size --log-file-max-size --log-file-max-size --logtostderr --namespace --namespace --namespace --registry-config --registry-config --registry-config --repository-cache --repository-cache --repository-cache --repository-config --repository-config --repository-config --skip-headers --skip-log-headers --stderrthreshold --stderrthreshold --stderrthreshold --v --v --v --vmodule --vmodule --vmodule -n -v"
-    allHelmLongFlags="--add-dir-header --alsologtostderr --debug --kube-apiserver --kube-apiserver --kube-apiserver --kube-context --kube-context --kube-context --kube-token --kube-token --kube-token --kubeconfig --kubeconfig --kubeconfig --log-backtrace-at --log-backtrace-at --log-backtrace-at --log-dir --log-dir --log-dir --log-file --log-file --log-file --log-file-max-size --log-file-max-size --log-file-max-size --logtostderr --namespace --namespace --namespace --registry-config --registry-config --registry-config --repository-cache --repository-cache --repository-cache --repository-config --repository-config --repository-config --skip-headers --skip-log-headers --stderrthreshold --stderrthreshold --stderrthreshold --v --v --v --vmodule --vmodule --vmodule"
+    allHelmGlobalFlags="--debug --kube-apiserver --kube-apiserver --kube-apiserver --kube-context --kube-context --kube-context --kube-token --kube-token --kube-token --kubeconfig --kubeconfig --kubeconfig --namespace --namespace --namespace --registry-config --registry-config --registry-config --repository-cache --repository-cache --repository-cache --repository-config --repository-config --repository-config -n"
+    allHelmLongFlags="--debug --kube-apiserver --kube-apiserver --kube-apiserver --kube-context --kube-context --kube-context --kube-token --kube-token --kube-token --kubeconfig --kubeconfig --kubeconfig --namespace --namespace --namespace --registry-config --registry-config --registry-config --repository-cache --repository-cache --repository-cache --repository-config --repository-config --repository-config "
 fi
 
 #####################
@@ -238,7 +238,7 @@ else
     _completionTests_verifyCompletion "helm get " "all hooks manifest notes values"
 fi
 _completionTests_verifyCompletion "helm get h" "hooks"
-_completionTests_verifyCompletion "helm completion " "bash zsh"
+_completionTests_verifyCompletion "helm completion " "bash fish zsh"
 _completionTests_verifyCompletion "helm completion z" "zsh"
 _completionTests_verifyCompletion "helm plugin " "install list uninstall update"
 _completionTests_verifyCompletion "helm plugin u" "uninstall update"
@@ -256,13 +256,13 @@ _completionTests_verifyCompletion "helm plugin --namespace ns " "install list un
 _completionTests_verifyCompletion "helm plugin --namespace ns u" "uninstall update"
 
 # With validArgs
-_completionTests_verifyCompletion "helm completion " "bash zsh"
+_completionTests_verifyCompletion "helm completion " "bash fish zsh"
 _completionTests_verifyCompletion "helm completion z" "zsh"
-_completionTests_verifyCompletion "helm --debug completion " "bash zsh"
+_completionTests_verifyCompletion "helm --debug completion " "bash fish zsh"
 _completionTests_verifyCompletion "helm --debug completion z" "zsh"
-_completionTests_verifyCompletion "helm -n ns completion " "bash zsh"
+_completionTests_verifyCompletion "helm -n ns completion " "bash fish zsh"
 _completionTests_verifyCompletion "helm -n ns completion z" "zsh"
-_completionTests_verifyCompletion "helm --namespace ns completion " "bash zsh"
+_completionTests_verifyCompletion "helm --namespace ns completion " "bash fish zsh"
 _completionTests_verifyCompletion "helm --namespace ns completion z" "zsh"
 
 # Completion of flags
@@ -274,12 +274,10 @@ else
     _completionTests_verifyCompletion "helm --kubecon" "--kubeconfig --kubeconfig --kubeconfig"
 fi
 if [ ! -z ${ROBOT_HELM_V3} ]; then
-    _completionTests_verifyCompletion "helm -v" "-v"
+    _completionTests_verifyCompletion "helm -n" "-n"
     if [ "$SHELL_TYPE" = bash ]; then
-        _completionTests_verifyCompletion "helm --v" "--v= --vmodule= --v --vmodule"
         _completionTests_verifyCompletion "helm --name" "--namespace= --namespace"
     else
-        _completionTests_verifyCompletion "helm --v" "--v --vmodule --v --vmodule --v --vmodule"
         _completionTests_verifyCompletion "helm --name" "--namespace --namespace --namespace"
     fi
 fi
@@ -288,14 +286,6 @@ _completionTests_verifyCompletion "helm -" "$allHelmGlobalFlags"
 _completionTests_verifyCompletion "helm --" "$allHelmLongFlags"
 _completionTests_verifyCompletion "helm show -" "$allHelmGlobalFlags"
 _completionTests_verifyCompletion "helm show --" "$allHelmLongFlags"
-
-if [ "$SHELL_TYPE" = bash ]; then
-    _completionTests_verifyCompletion "helm --s" "--skip-headers --skip-log-headers --stderrthreshold --stderrthreshold="
-    _completionTests_verifyCompletion "helm show --s" "--skip-headers --skip-log-headers --stderrthreshold --stderrthreshold="
-else
-    _completionTests_verifyCompletion "helm --s" "--skip-headers --skip-log-headers --stderrthreshold --stderrthreshold --stderrthreshold"
-    _completionTests_verifyCompletion "helm show --s" "--skip-headers --skip-log-headers --stderrthreshold --stderrthreshold --stderrthreshold"
-fi
 
 _completionTests_verifyCompletion "helm -n" "-n"
 _completionTests_verifyCompletion "helm show -n" "-n"
@@ -310,7 +300,7 @@ else
 fi
 if [ ! -z ${ROBOT_HELM_V3} ]; then
     _completionTests_verifyCompletion "helm --namespace mynamespace get h" "hooks"
-    _completionTests_verifyCompletion "helm -v 3 get " "all hooks manifest notes values"
+    _completionTests_verifyCompletion "helm -n mynamespace get " "all hooks manifest notes values"
     if [ "$SHELL_TYPE" = bash ]; then
         _completionTests_verifyCompletion "helm get --name" "--namespace= --namespace"
     else
@@ -467,7 +457,7 @@ if [ ! -z ${ROBOT_HELM_V3} ]; then
     _completionTests_verifyCompletion "helm upgrade release zz" "zztest1/ zztest2/ zztest2file"
     _completionTests_verifyCompletion "helm upgrade release nginx/n" "nginx/nginx nginx/nginx-test"
 
-    _completionTests_verifyCompletion "helm show values ngin" "nginx/ nginx/."
+    _completionTests_verifyCompletion "helm show values ngin" "nginx/"
 
     \rm $tmpFiles
 fi

--- a/scripts/completion-tests/test-completion.sh
+++ b/scripts/completion-tests/test-completion.sh
@@ -198,44 +198,47 @@ EOF
               -e KUBECONFIG=${KUBECONFIG} \
               ${BASH_IMAGE} bash -c "source ${COMP_SCRIPT}"
 
-   ########################################
-   # Zsh completion tests
-   ########################################
-   ZSH_IMAGE=completion-zsh
-
-   echo;echo;
-   docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
-      FROM zshusers/zsh:5.7
-      # This will install the SSL certificates necessary for helm repo update to work
-      RUN apt-get update && apt-get install -y wget
-      COPY ./ ${COMP_DIR}/
-EOF
-   docker run --rm \
-              -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
-              -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
-              -e COMP_DIR=${COMP_DIR} \
-              -e KUBECONFIG=${KUBECONFIG} \
-              ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
-
-   ########################################
-   # Zsh alpine/busybox completion tests
-   # https://github.com/helm/helm/pull/6327
-   ########################################
-   ZSH_IMAGE=completion-zsh-alpine
-
-   echo;echo;
-   docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
-      FROM alpine
-      RUN apk update && apk add zsh ca-certificates
-      COPY ./ ${COMP_DIR}/
-EOF
-   docker run --rm \
-              -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
-              -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
-              -e COMP_DIR=${COMP_DIR} \
-              -e KUBECONFIG=${KUBECONFIG} \
-              ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
-
+# Zsh completion tests no longer work now that helm
+# has moved to native zsh completion
+#
+#   ########################################
+#   # Zsh completion tests
+#   ########################################
+#   ZSH_IMAGE=completion-zsh
+#
+#   echo;echo;
+#   docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
+#      FROM zshusers/zsh:5.7
+#      # This will install the SSL certificates necessary for helm repo update to work
+#      RUN apt-get update && apt-get install -y wget
+#      COPY ./ ${COMP_DIR}/
+#EOF
+#   docker run --rm \
+#              -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
+#              -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
+#              -e COMP_DIR=${COMP_DIR} \
+#              -e KUBECONFIG=${KUBECONFIG} \
+#              ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
+#
+#   ########################################
+#   # Zsh alpine/busybox completion tests
+#   # https://github.com/helm/helm/pull/6327
+#   ########################################
+#   ZSH_IMAGE=completion-zsh-alpine
+#
+#   echo;echo;
+#   docker build -t ${ZSH_IMAGE} -f - ${COMP_DIR} <<- EOF
+#      FROM alpine
+#      RUN apk update && apk add zsh ca-certificates
+#      COPY ./ ${COMP_DIR}/
+#EOF
+#   docker run --rm \
+#              -e ROBOT_HELM_V3=${ROBOT_HELM_V3} \
+#              -e ROBOT_DEBUG_LEVEL=${ROBOT_DEBUG_LEVEL} \
+#              -e COMP_DIR=${COMP_DIR} \
+#              -e KUBECONFIG=${KUBECONFIG} \
+#              ${ZSH_IMAGE} zsh -c "source ${COMP_SCRIPT}"
+#
 fi
 
 ########################################
@@ -261,11 +264,14 @@ if [ "$(uname)" == "Darwin" ]; then
       bash -c "source ${COMP_SCRIPT}"
    fi
 
-   if which zsh>/dev/null; then
-      echo;echo;
-      echo "Completion tests for zsh running locally"
-      zsh -c "source ${COMP_SCRIPT}"
-   fi
+# Zsh completion tests no longer work now that helm
+# has moved to native zsh completion
+#
+#   if which zsh>/dev/null; then
+#      echo;echo;
+#      echo "Completion tests for zsh running locally"
+#      zsh -c "source ${COMP_SCRIPT}"
+#   fi
 fi
 
 # Indicate if anything failed during the run


### PR DESCRIPTION
Recent helm improvements had broken the tests:
- klog flags are no longer shown
- fish completion has been added
- new global flags
- zsh completion is now native (not supported for testing)

This PR makes them pass again.
*Note*: zsh completion can no longer be tested as we do here as helm now uses native zsh completion