### PR TITLE
Each completion should be on its own line

### DIFF
--- a/scripts/completion-tests/completionTests.sh
+++ b/scripts/completion-tests/completionTests.sh
@@ -136,7 +136,10 @@ cat > ${PLUGIN_DIR}/plugin.complete << EOF
 
 if [ "\$2" = "config" ]; then
     echo "case-config"
-    echo "gryffindor slytherin ravenclaw hufflepuff"
+    echo "gryffindor"
+    echo "slytherin"
+    echo "ravenclaw"
+    echo "hufflepuff"
     echo ":0"
     exit
 fi


### PR DESCRIPTION
It was working before because we happened to only check that the first
completion of the list was present.  With an optimisation coming to
Cobra, having more than one completion per line will always fail.
