### PR TITLE
Pip is not required on osx

### DIFF
--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -36,9 +36,16 @@ set_shell_debug_level 2
 REQUIRED_SYSTEM_COMMANDS=(
     "kubectl"
     "python3"
-    "pip"
     "virtualenv"
 )
+
+if [[ "$OSTYPE" != "darwin"* ]]; then
+   # not required on OSX, as pip is installed a python package
+   # during python3 install (via homebrew) and is accessible
+   # once inside the virtualenv
+   REQUIRED_SYSTEM_COMMANDS+=(pip)
+
+fi
 
 if [ "$CLUSTER_PROVIDER" == kind ]; then
    REQUIRED_SYSTEM_COMMANDS+=(kind)


### PR DESCRIPTION
scripts/acceptance.sh expects a number of core utils to be available on the system.

This includes "pip" (the python package manager).

On an OSX host, the pip _package_ is installed as part of the python3 installation (via homebrew) - however no system-command is created to access it.

However, once inside a virtual-environment pip _is_ available, as the module is wrapped by the `<venv>/bin/pip` script.